### PR TITLE
Release 0.38.0: committed joins now carry their own resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file. This change
 log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [0.38.0] - 2026-08-11
 ### Added
 - Each committed join in `ast.joins` now carries its own resolution confidence (`"fk"`, `"heuristic"`, `"synthetic"`, or `"manual"`) as a 6th element of the relation tuple, matching what join hints already exposed — so a client no longer has to guess (or re-derive from the picker) whether an already-drawn join is backed by a real foreign key.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file. This change
 log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Added
+- Each committed join in `ast.joins` now carries its own resolution confidence (`"fk"`, `"heuristic"`, `"synthetic"`, or `"manual"`) as a 6th element of the relation tuple, matching what join hints already exposed — so a client no longer has to guess (or re-derive from the picker) whether an already-drawn join is backed by a real foreign key.
 
 ## [0.37.3] - 2026-08-09
 ### Fixed

--- a/playground.docker-compose.yml
+++ b/playground.docker-compose.yml
@@ -18,7 +18,7 @@ services:
       retries: 10
 
   pine:
-    image: ahmadnazir/pine:0.37.3
+    image: ahmadnazir/pine:0.38.0
     container_name: pine_server
     depends_on:
       sample-db-ecommerce:

--- a/src/pine/ast/hints.clj
+++ b/src/pine/ast/hints.clj
@@ -67,16 +67,13 @@
 ;; regardless of :refers-to vs :referred-by direction - because relation-hints
 ;; always looks the via map up keyed by the context table. See docs/joins.md.
 ;;
-;; Only :foreign-key/:heuristic ever reach here - a real reference-map entry,
-;; tagged at schema-index time (db/postgres.clj). "synthetic" (the third
-;; :resolution value - see docs/joins.md) never comes from a via-details tag
-;; at all; it's set directly wherever a same-source join is fabricated
-;; on the fly (below), since nothing in the references map describes it.
-(defn- resolution-of [vd]
-  (case (last vd)
-    :foreign-key "fk"
-    :heuristic   "heuristic"))
-
+;; resolution-of (table/resolution-of - shared with ast/table.clj, which tags
+;; committed joins in ast.joins the same way) only ever sees :foreign-key/
+;; :heuristic here - a real reference-map entry, tagged at schema-index time
+;; (db/postgres.clj). "synthetic" (the third :resolution value - see
+;; docs/joins.md) never comes from a via-details tag at all; it's set
+;; directly wherever a same-source join is fabricated on the fly (below),
+;; since nothing in the references map describes it.
 (defn- create-hint-from-relation-array
   "context-rename/target-rename translate the context's/suggested table's own
   column back through whatever name a variable exposes it under on that side
@@ -94,7 +91,7 @@
                :column column
                :related-column related-column
                :parent (= direction :refers-to)
-               :resolution (resolution-of vd)})))
+               :resolution (table/resolution-of vd)})))
         via-details))
 
 (defn- variables-resolving-to

--- a/src/pine/ast/table.clj
+++ b/src/pine/ast/table.clj
@@ -54,6 +54,18 @@
   [rename col]
   (if (empty? rename) col (get rename col)))
 
+;; via-details look like:
+;; ["z"  "document"      "created_by"  :refers-to   "y"  "employee" "id" :foreign-key]
+;;
+;; Only :foreign-key/:heuristic ever reach here as a real reference-map
+;; via-tuple tag (schema-index time, db/postgres.clj) - "synthetic"/"manual"
+;; are never derived from one, since neither corresponds to an actual FK or
+;; heuristic reference at all (see same-source-join and update-joins below).
+(defn resolution-of [vd]
+  (case (last vd)
+    :foreign-key "fk"
+    :heuristic   "heuristic"))
+
 (defn- join-helper
   "Find the references between the tables, get the columns for the first
   reference and return the pair of alias and columns that will be used for the join.
@@ -77,11 +89,16 @@
           col                   (translate-column rename1 raw-col)
           f-col                 (translate-column rename2 raw-f-col)
           rejected?             (or (and (some? raw-col) (seq rename1) (nil? col))
-                                    (and (some? raw-f-col) (seq rename2) (nil? f-col)))]
+                                    (and (some? raw-f-col) (seq rename2) (nil? f-col)))
+                                ;; `join` is nil for an invalid explicit .hint_col (no via
+                                ;; entry matched col-key) - resolution-of throws on a nil/
+                                ;; unmatched tag, so guard it the same way the columns above
+                                ;; already tolerate a nil raw-col/raw-f-col.
+          resolution            (when join (resolution-of join))]
       (when-not rejected?
         (if (= direction :of)
-          [a2 f-col :of a1 col]
-          [a1 col :has a2 f-col])))))
+          [a2 f-col :of a1 col resolution]
+          [a1 col :has a2 f-col resolution])))))
 
 (defn- has-id-column? [references {:keys [table schema]}]
   (let [columns (if schema
@@ -121,7 +138,7 @@
            :let [id1 (translate-column rename1 "id")
                  id2 (translate-column rename2 "id")]
            :when (and (= t1 t2) (has-id-column? references c1) id1 id2)]
-       [a1 id1 :has a2 id2]))))
+       [a1 id1 :has a2 id2 "synthetic"]))))
 
 ;; TODO: use spec for the state value i.e. first arg
 (defn- join-tables [{:keys [references aliases]} x y c parent]
@@ -161,7 +178,7 @@
       ;; In "a | b .a_id = .id", left-col is "id" (from a), right-col is "a_id" (from b)
       (and join-left-column join-right-column)
       (let [x (-> state :aliases (get from-alias))
-            join-result [(x :alias) join-left-column :has (current :alias) join-right-column]]
+            join-result [(x :alias) join-left-column :has (current :alias) join-right-column "manual"]]
         (update state :joins conj [(x :alias) (current :alias) join-result join]))
 
       :else (let [x (-> state :aliases (get from-alias))

--- a/src/pine/version.clj
+++ b/src/pine/version.clj
@@ -1,3 +1,3 @@
 (ns pine.version)
 
-(def version "0.37.3")
+(def version "0.38.0")

--- a/test/pine/ast_test.clj
+++ b/test/pine/ast_test.clj
@@ -170,51 +170,51 @@
            (generate :joins "a | b .a_id")))
 
     ;; Explicit join columns
-    (is (= [["a_0" "b_1" ["a_0" "id" :has "b_1" "a_id"] nil]]
+    (is (= [["a_0" "b_1" ["a_0" "id" :has "b_1" "a_id" "manual"] nil]]
            (generate :joins "a | b .a_id = .id"))))
 
   (testing "Generate ast for `join` where there is a relation"
-    (is (= [["c_0" "e_1" ["c_0" "id" :has "e_1" "company_id"] nil]]
+    (is (= [["c_0" "e_1" ["c_0" "id" :has "e_1" "company_id" "fk"] nil]]
            (generate :joins "company | employee")))
-    (is (= [["c_0" "e_1" ["c_0" "id" :has "e_1" "company_id"] nil]]
+    (is (= [["c_0" "e_1" ["c_0" "id" :has "e_1" "company_id" "fk"] nil]]
            (generate :joins "company | employee .company_id")))
-    (is (= [["c_0" "e_1" ["c_0" nil :has "e_1" nil] nil]]
+    (is (= [["c_0" "e_1" ["c_0" nil :has "e_1" nil nil] nil]]
            (generate :joins "company | employee .employee_id"))) ;; trying with incorrect id
     )
   (testing "Generate ast for `join` where there is ambiguity"
-    (is (= [["e_0" "d_1" ["e_0" "id" :has "d_1" "created_by"] nil]]
+    (is (= [["e_0" "d_1" ["e_0" "id" :has "d_1" "created_by" "fk"] nil]]
            (generate :joins "employee | document .created_by")))
-    (is (= [["e_0" "d_1" ["e_0" "id" :has "d_1" "employee_id"] nil]]
+    (is (= [["e_0" "d_1" ["e_0" "id" :has "d_1" "employee_id" "fk"] nil]]
            (generate :joins "employee | document .employee_id"))))
 
   (testing "Generate ast for `join` using self join"
     ;; By default, we narrow the results
     ;; i.e. we join with the child
-    (is (= [["e_0" "e_1" ["e_0" "id" :has "e_1" "reports_to"] nil]]
+    (is (= [["e_0" "e_1" ["e_0" "id" :has "e_1" "reports_to" "fk"] nil]]
            (generate :joins "employee | employee")))
-    (is (= [["e_0" "e_1" ["e_0" "id" :has "e_1" "reports_to"] nil]]
+    (is (= [["e_0" "e_1" ["e_0" "id" :has "e_1" "reports_to" "fk"] nil]]
            (generate :joins "employee | employee .reports_to")))
 
     ;; However, we can exlicitly saw that the table is a parent using the `^` character
-    (is (= [["e_0" "e_1" ["e_0" "reports_to" :of "e_1" "id"] nil]]
+    (is (= [["e_0" "e_1" ["e_0" "reports_to" :of "e_1" "id" "fk"] nil]]
            (generate :joins "employee | employee :parent")))
-    (is (= [["e_0" "e_1" ["e_0" "reports_to" :of "e_1" "id"] nil]]
+    (is (= [["e_0" "e_1" ["e_0" "reports_to" :of "e_1" "id" "fk"] nil]]
            (generate :joins "employee | employee :parent .reports_to"))))
 
   (testing "Generate ast for `join` with explicit columns"
     ;; Basic explicit columns with real tables
-    (is (= [["c_0" "e_1" ["c_0" "id" :has "e_1" "company_id"] nil]]
+    (is (= [["c_0" "e_1" ["c_0" "id" :has "e_1" "company_id" "manual"] nil]]
            (generate :joins "company | employee .company_id = .id")))
 
     ;; Explicit columns with different column names
-    (is (= [["a_0" "b_1" ["a_0" "custom_id" :has "b_1" "foreign_id"] nil]]
+    (is (= [["a_0" "b_1" ["a_0" "custom_id" :has "b_1" "foreign_id" "manual"] nil]]
            (generate :joins "a | b .foreign_id = .custom_id")))
 
     ;; Explicit columns with join type
-    (is (= [["c_0" "e_1" ["c_0" "id" :has "e_1" "company_id"] "LEFT"]]
+    (is (= [["c_0" "e_1" ["c_0" "id" :has "e_1" "company_id" "manual"] "LEFT"]]
            (generate :joins "company | employee .company_id = .id :left")))
 
-    (is (= [["c_0" "e_1" ["c_0" "id" :has "e_1" "company_id"] "RIGHT"]]
+    (is (= [["c_0" "e_1" ["c_0" "id" :has "e_1" "company_id" "manual"] "RIGHT"]]
            (generate :joins "company | employee .company_id = .id :right"))))
 
   (testing "Generate ast for `count`"


### PR DESCRIPTION
Committed joins in ast.joins now carry a resolution field ("fk", "heuristic", "synthetic", or "manual") describing how each join was actually resolved - the same vocabulary already exposed on not-yet-committed join hints. Previously this info only existed transiently on the hint that produced a join and was lost the moment it was committed, so a client had no way to tell whether an already-drawn join was backed by a real foreign key without re-deriving it from the original hint.

Bumped to 0.38.0 (minor - this adds a field, not just a fix) and moved the changelog entry accordingly.