### PR TITLE
Release 0.38.1: expose group-by columns in the build response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file. This change
 log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [0.38.1] - 2026-08-13
 ### Fixed
 - The build response now includes the columns a `group:` clause is grouping by — previously missing entirely, so a client had no way to tell a `group:` was present once committed, even though it was being evaluated correctly.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 ### Fixed
-- `/build`'s response now includes `ast.group` — previously pruned away entirely (not in `prune-ast`'s field whitelist), so a client had no way to know a `group:` clause existed once committed, even though the grouped columns were otherwise fully evaluated.
+- The build response now includes the columns a `group:` clause is grouping by — previously missing entirely, so a client had no way to tell a `group:` was present once committed, even though it was being evaluated correctly.
 
 ## [0.38.0] - 2026-08-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file. This change
 log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- `/build`'s response now includes `ast.group` — previously pruned away entirely (not in `prune-ast`'s field whitelist), so a client had no way to know a `group:` clause existed once committed, even though the grouped columns were otherwise fully evaluated.
 
 ## [0.38.0] - 2026-08-11
 ### Added

--- a/playground.docker-compose.yml
+++ b/playground.docker-compose.yml
@@ -18,7 +18,7 @@ services:
       retries: 10
 
   pine:
-    image: ahmadnazir/pine:0.38.0
+    image: ahmadnazir/pine:0.38.1
     container_name: pine_server
     depends_on:
       sample-db-ecommerce:

--- a/src/pine/api.clj
+++ b/src/pine/api.clj
@@ -98,7 +98,7 @@
 (defn- prune-ast
   "Prune a generated state down to the :ast value returned to the frontend."
   [state]
-  (-> (select-keys state [:hints :selected-tables :joins :context :current :operation :columns :order :where :prettified :ranges :assign])
+  (-> (select-keys state [:hints :selected-tables :joins :context :current :operation :columns :order :where :group :prettified :ranges :assign])
       (update :selected-tables #(mapv prune-table %))
       (assoc :variables
              (into {} (for [[k v] (:variables state)] [k (prune-var-ast v)])))

--- a/src/pine/version.clj
+++ b/src/pine/version.clj
@@ -1,3 +1,3 @@
 (ns pine.version)
 
-(def version "0.38.0")
+(def version "0.38.1")

--- a/test/pine/api_test.clj
+++ b/test/pine/api_test.clj
@@ -68,6 +68,14 @@
               table (concat (:tables var-ast) (:selected-tables var-ast))]
         (assert-clean-table table)))
 
+    (testing ":group is exposed to the frontend, not pruned away entirely"
+      ;; Previously absent from prune-ast's select-keys whitelist, so `ast.group`
+      ;; was always undefined regardless of what the state actually computed -
+      ;; the frontend (canvas mode's group-by chips, client.ts's GroupColumn)
+      ;; had no way to know a `group:` clause even existed once committed.
+      (is (= [{:alias "t" :column "title"}]
+             (map #(select-keys % [:alias :column]) (:group single-block)))))
+
     (testing "an earlier variable's own entry is unaffected by how many blocks chain after it"
       ;; The actual bug wasn't about absolute size (which is arbitrary and brittle to
       ;; pin to a byte count) — it was that x's entry kept growing every time another


### PR DESCRIPTION
The build response now includes the columns a group: clause is grouping by - previously missing entirely, so a client had no way to tell a group: was present once committed, even though it was being evaluated correctly.

Patch bump (0.38.0 -> 0.38.1) - fix only, no new feature.