### PR TITLE
Release 0.38.2: bind to loopback by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.38.2] - 2026-08-17
+### Security
+- The server now binds to `127.0.0.1` (loopback only) by default, instead of every network interface. The server has no authentication, so the old default left it reachable from the whole LAN, not just the local machine. Set `PINE_HOST` to change it -- the dockerized playground sets it to `0.0.0.0`, since Docker's own port publish already restricts external access to loopback.
+
 ## [0.38.1] - 2026-08-13
 ### Fixed
 - The build response now includes the columns a `group:` clause is grouping by — previously missing entirely, so a client had no way to tell a `group:` was present once committed, even though it was being evaluated correctly.

--- a/playground.docker-compose.yml
+++ b/playground.docker-compose.yml
@@ -18,7 +18,7 @@ services:
       retries: 10
 
   pine:
-    image: ahmadnazir/pine:0.38.1
+    image: ahmadnazir/pine:0.38.2
     container_name: pine_server
     depends_on:
       sample-db-ecommerce:
@@ -28,6 +28,13 @@ services:
     mem_limit: 384m
     environment:
       JAVA_TOOL_OPTIONS: "-XX:MaxRAMPercentage=70.0 -XX:+UseSerialGC"
+      # pine-lang now defaults its bind host to loopback-only (see
+      # src/pine/core.clj) -- inside this container's own network namespace
+      # that would make it unreachable even from the host, since Docker's
+      # port publish above needs the process to be listening on the
+      # container's 0.0.0.0. The "127.0.0.1:33333:33333" mapping is what
+      # actually restricts this to localhost from the outside.
+      PINE_HOST: "0.0.0.0"
 
   init:
     image: curlimages/curl:8.7.1

--- a/src/pine/core.clj
+++ b/src/pine/core.clj
@@ -5,5 +5,15 @@
 
 #_{:clj-kondo/ignore [:unused-binding]}
 (defn -main [& args]
-  (run-jetty app {:port 33333 :join? false}))
+  ;; Defaults to loopback-only. This server has no authentication of any
+  ;; kind (see pine.api's wide-open CORS). Binding all interfaces by
+  ;; default would leave it reachable from the whole LAN, not just this
+  ;; machine -- with no :host set, Jetty bound 0.0.0.0 (checked with
+  ;; `ss -ltnp` before this change). The dockerized playground needs the
+  ;; opposite -- Docker's own port publish
+  ;; (playground.docker-compose.yml's "127.0.0.1:33333:33333") already
+  ;; restricts host-side exposure, but the process inside the container
+  ;; must still bind its own 0.0.0.0 for that publish to reach it at all --
+  ;; so that compose file sets PINE_HOST=0.0.0.0 explicitly.
+  (run-jetty app {:port 33333 :host (or (System/getenv "PINE_HOST") "127.0.0.1") :join? false}))
 

--- a/src/pine/version.clj
+++ b/src/pine/version.clj
@@ -1,3 +1,3 @@
 (ns pine.version)
 
-(def version "0.38.1")
+(def version "0.38.2")


### PR DESCRIPTION
## Summary
- Security fix: the server has no authentication, and previously bound every network interface by default (Jetty's own default with no `:host` set), leaving it reachable from the whole LAN rather than just the local machine.
- It now binds `127.0.0.1` (loopback only) by default. `PINE_HOST` overrides this -- the dockerized playground sets it to `0.0.0.0`, since Docker's own port publish (`playground.docker-compose.yml`) already restricts external access to loopback.

## Test plan
- [x] `clj -M:test` -- 501 assertions, 0 failures
- [x] `./scripts/check-version-sync.sh`
- [x] `clj -M:fmt fix` (no changes needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)