### PR TITLE
Release 0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file. This change
 log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [0.39.0] - 2026-08-22
 ### Fixed
 - A heuristic join (a naming-convention guess, not a real foreign key) whose two columns had different DB types — e.g. one stored as `varchar`, the other as `uuid` — generated a join Postgres rejected outright (`operator does not exist: character varying = uuid`), since nothing checked the columns' types were even compatible before joining them. Each committed join's relation tuple now carries a 7th `needs-cast?` element; when true, both sides of the generated `ON` clause are cast to `text`. Real FK joins are never affected — the constraint already guarantees the types are compatible.
 - A table with no foreign key and no heuristic match to another table never showed up as a table hint, even though its columns were fully indexed — for example, a lookup table nothing else references. Table hints now fall back to the plain schema index for a table like this, so it can still be a starting point for a query. It still won't show up as a join target, since it genuinely has nothing to join through.

--- a/playground.docker-compose.yml
+++ b/playground.docker-compose.yml
@@ -18,7 +18,7 @@ services:
       retries: 10
 
   pine:
-    image: ahmadnazir/pine:0.38.2
+    image: ahmadnazir/pine:0.39.0
     container_name: pine_server
     depends_on:
       sample-db-ecommerce:

--- a/src/pine/version.clj
+++ b/src/pine/version.clj
@@ -1,3 +1,3 @@
 (ns pine.version)
 
-(def version "0.38.2")
+(def version "0.39.0")


### PR DESCRIPTION
## Summary
- Heuristic joins between columns of different DB types (e.g. varchar vs uuid) now cast both sides to text instead of generating SQL Postgres rejects outright.
- A table with no foreign key and no heuristic match to another table now still shows up as a table hint (it just won't be a join target), instead of being invisible.
- pg_catalog/information_schema tables no longer leak into hints as a side effect of the above.
- New `POST /api/v1/connections/:id/reindex` endpoint to pick up schema changes without restarting the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)