### PR TITLE
Release 0.40.0: query logging no longer deadlocks the server, and connections stop leaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file. This change
 log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- A query could hang forever, taking every other database-backed request down with it, if whatever launched the server was not reading the server's own standard output. The server printed the full SQL of every query it ran; once nothing drained that stream, its buffer filled and each print blocked permanently. Endpoints that never touch the database kept working normally, including `/api/v1/build`, which made the server look healthy while every query sat unanswered. Per-query logging is now off unless `PINE_LOG_QUERIES=1` is set. Startup messages, which are few and only appear when a connection is indexed, are unchanged.
+- Registering a connection that was already registered leaked a database connection every time. A connection's id is derived from its own host and port, so re-registering the same database always overwrote the existing entry — but the pool it displaced was never closed, and the pool settings keep one connection open at all times. Each stale pool therefore held a real database connection for the life of the process; 32 of them accumulated in a single desktop session, against a default server limit of 100. Registering the same database as the same user now reuses the existing pool instead of building another one.
+
+### Changed
+- Registering a **different** database or user under a connection id that is already taken now fails with an explanatory error, instead of silently taking that id over. Because a connection id is only a host and port, two databases on the same server share one id and could never both be registered — the old behaviour pointed the existing id at the new database, so queries a caller believed were running against the first database quietly ran against the second. Disconnect the existing connection first to reuse the id. The error names the id and says why.
+
+### Security
+- The server no longer prints every query's SQL, including literal values, to standard output by default. Set `PINE_LOG_QUERIES=1` to opt back in when debugging.
 
 ## [0.39.0] - 2026-08-22
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file. This change
 log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [0.40.0] - 2026-08-26
 ### Fixed
 - A query could hang forever, taking every other database-backed request down with it, if whatever launched the server was not reading the server's own standard output. The server printed the full SQL of every query it ran; once nothing drained that stream, its buffer filled and each print blocked permanently. Endpoints that never touch the database kept working normally, including `/api/v1/build`, which made the server look healthy while every query sat unanswered. Per-query logging is now off unless `PINE_LOG_QUERIES=1` is set. Startup messages, which are few and only appear when a connection is indexed, are unchanged.
 - Registering a connection that was already registered leaked a database connection every time. A connection's id is derived from its own host and port, so re-registering the same database always overwrote the existing entry — but the pool it displaced was never closed, and the pool settings keep one connection open at all times. Each stale pool therefore held a real database connection for the life of the process; 32 of them accumulated in a single desktop session, against a default server limit of 100. Registering the same database as the same user now reuses the existing pool instead of building another one.

--- a/playground.docker-compose.yml
+++ b/playground.docker-compose.yml
@@ -18,7 +18,7 @@ services:
       retries: 10
 
   pine:
-    image: ahmadnazir/pine:0.39.0
+    image: ahmadnazir/pine:0.40.0
     container_name: pine_server
     depends_on:
       sample-db-ecommerce:

--- a/src/pine/db/connections.clj
+++ b/src/pine/db/connections.clj
@@ -70,11 +70,68 @@
            :label (make-connection-label (get-connection-pool id))})
         @pools))
 
-(defn add-connection-pool [connection]
-  (let [pool (create-pool connection)
-        id (make-connection-id pool)]
-    (swap! pools assoc id pool)
-    id))
+(defn- same-target?
+  "Whether an already-registered pool points at the same database, as the
+  same user, as a newly built one. Compared on the JDBC URL and username
+  rather than the connection id, because the id is only `host:port` -- two
+  different databases on one server share an id, so matching ids alone does
+  not mean the pools are interchangeable."
+  [existing candidate]
+  (and (instance? HikariDataSource existing)
+       (= (.getJdbcUrl ^HikariDataSource existing) (.getJdbcUrl candidate))
+       (= (.getUsername ^HikariDataSource existing) (.getUsername candidate))))
+
+(defn add-connection-pool
+  "Registers a pool for `connection` and returns its id.
+
+  Never disturbs a pool that is already registered. Registering the same
+  database as the same user reuses the existing pool; anything else that
+  would land on an id already in use is rejected.
+
+  Both halves fix real problems. A connection id is derived from the pool's
+  own `host:port`, so re-registering the same database always lands on the
+  same key. This used to be a bare `swap! pools assoc`, which overwrote the
+  entry and left the displaced HikariDataSource open with nothing
+  referencing it. The pool config sets `minimumIdle 1`, so every orphan held
+  a real Postgres connection for the life of the process -- 32 leaked pools
+  turned up in a single desktop session, against Postgres's default limit of
+  100. A long-running session would eventually be unable to connect at all.
+
+  Rejecting rather than replacing is deliberate. Closing the displaced pool
+  would fix the leak, but it would also abort queries still running on it --
+  and because the id is only `host:port`, the pool being closed could belong
+  to a *different* database the user is actively querying. Note this takes
+  nothing away: two databases on one server share an id, so they could never
+  coexist in this map anyway. Replacing silently pointed an existing
+  connection id at a different database, which is a correctness hazard on
+  top of the leak. An explicit error is the honest version of a limitation
+  that was already there. Callers that genuinely want to swap targets can
+  `remove-connection-pool` first, which closes the pool properly.
+
+  Reuse compares the JDBC URL and username, so a changed *password* reuses
+  the existing pool rather than rebuilding it. If credentials were rotated
+  server-side, disconnect and reconnect to pick them up."
+  [connection]
+  (let [candidate (create-pool connection)
+        id (make-connection-id candidate)
+        existing (@pools id)]
+    (cond
+      (nil? existing)
+      (do (swap! pools assoc id candidate) id)
+
+      (same-target? existing candidate)
+      ;; Closing the redundant candidate is what stops the leak -- it has
+      ;; already opened its minimumIdle connection by this point.
+      (do (.close candidate) id)
+
+      :else
+      (do (.close candidate)
+          (throw (ex-info
+                  (format (str "Connection id \"%s\" is already in use by a different database or user. "
+                               "pine identifies a connection by host and port only, so two databases on the "
+                               "same server cannot both be registered. Disconnect \"%s\" first.")
+                          id id)
+                  {:id id}))))))
 
 (defn remove-connection-pool [id]
   (.close (get-connection-pool id))

--- a/src/pine/db/postgres.clj
+++ b/src/pine/db/postgres.clj
@@ -230,6 +230,26 @@ WHERE table_schema NOT IN ('pg_catalog', 'information_schema')"]
                      :else (get-references-helper id))]
     (index-references references)))
 
+(def ^:private log-queries?
+  "Per-query logging, opt-in via PINE_LOG_QUERIES=1.
+
+  These prints used to be unconditional, which was a real hazard rather than
+  just noise. Whatever launches pine-server has to drain its stdout; if
+  nothing does, the pipe buffer fills and every `prn` blocks forever, which
+  deadlocks every endpoint that runs SQL. beamlynx-desktop hit exactly that
+  -- 17 threads parked in StreamEncoder.write inside run-query, while
+  /api/v1/build kept answering because it reads an in-memory index and never
+  prints. The consumer side is fixed too (beamlynx-desktop's
+  server-process.ts now drains stdout), but a firehose that prints every
+  query's full SQL should not be on by default regardless: it is also the
+  query text, including literal values, going to a stream nobody asked to
+  receive it on."
+  (= "1" (System/getenv "PINE_LOG_QUERIES")))
+
+(defn- log-query [fmt & args]
+  (when log-queries?
+    (prn (apply format fmt args))))
+
 (defn convert-param-for-postgres
   "Convert parameter values to appropriate types for PostgreSQL"
   [param]
@@ -246,21 +266,21 @@ WHERE table_schema NOT IN ('pg_catalog', 'information_schema')"]
   (let [pool (connections/get-connection-pool id)
         {:keys [query params]} query
         params (map convert-param-for-postgres params)
-        _ (prn (format "Running query: %s" query))
+        _ (log-query "Running query: %s" query)
         result (with-open [conn (.getConnection pool)]
                  (jdbc/query {:connection conn} (cons query params) {:as-arrays? true :identifiers identity}))
-        _ (prn "Done!")]
+        _ (log-query "Done!")]
     result))
 
 (defn run-action-query [id query]
   (let [pool (connections/get-connection-pool id)
         {:keys [query params]} query
         params (map convert-param-for-postgres params)
-        _ (prn (format "Running action: %s" query))
+        _ (log-query "Running action: %s" query)
         result (with-open [conn (.getConnection pool)]
                  (jdbc/execute! {:connection conn} (cons query params)))
         affected-rows (first result)
-        _ (prn (format "Affected rows: %d" affected-rows))]
+        _ (log-query "Affected rows: %d" affected-rows)]
     affected-rows))
 
 (defn run-action-queries-in-transaction
@@ -275,10 +295,10 @@ WHERE table_schema NOT IN ('pg_catalog', 'information_schema')"]
        (fn [tx]
          (mapv (fn [{:keys [table query params]}]
                  (let [params (map convert-param-for-postgres (or params []))
-                       _ (prn (format "Running action (tx): %s" query))
+                       _ (log-query "Running action (tx): %s" query)
                        result (jdbc/execute! tx (cons query params) {:transaction? false})
                        affected (first result)]
-                   (prn (format "Affected rows: %d" affected))
+                   (log-query "Affected rows: %d" affected)
                    [(or table "table") affected]))
                queries))))))
 
@@ -293,12 +313,12 @@ WHERE table_schema NOT IN ('pg_catalog', 'information_schema')"]
                        (clojure.string/starts-with? trimmed-query "WITH")
                        (clojure.string/starts-with? trimmed-query "SHOW")
                        (clojure.string/starts-with? trimmed-query "EXPLAIN"))
-        _ (prn (format "Running raw SQL: %s" sql-query))
+        _ (log-query "Running raw SQL: %s" sql-query)
         result (with-open [conn (.getConnection pool)]
                  (if is-select?
                    (jdbc/query {:connection conn} sql-query {:as-arrays? true :identifiers identity})
                    (jdbc/execute! {:connection conn} sql-query)))
-        _ (prn "Done!")]
+        _ (log-query "Done!")]
     (if is-select?
       result
       ;; Return array format for action queries to match expected structure

--- a/src/pine/version.clj
+++ b/src/pine/version.clj
@@ -1,3 +1,3 @@
 (ns pine.version)
 
-(def version "0.39.0")
+(def version "0.40.0")

--- a/test/pine/db/connections_test.clj
+++ b/test/pine/db/connections_test.clj
@@ -3,7 +3,8 @@
    [clojure.test :refer [deftest is testing]]
    [pine.db.connections :as connections]
    [pine.db.main :as db]
-   [pine.db.postgres :as postgres]))
+   [pine.db.postgres :as postgres])
+  (:import (com.zaxxer.hikari HikariDataSource)))
 
 (defn- fake-pool [closed?]
   (reify java.io.Closeable
@@ -43,3 +44,80 @@
         (is (= {:call 1} (@db/references "conn-reindex")))
         (db/reindex-references "conn-reindex")
         (is (= {:call 2} (@db/references "conn-reindex")))))))
+
+;; A real HikariDataSource subclass, not a reify: add-connection-pool has to
+;; distinguish a realized pool from the lazy thunk get-connection-pool also
+;; accepts, so it checks `instance? HikariDataSource`. The no-arg
+;; constructor is the "configure later" mode and starts no pool, so nothing
+;; here touches a database.
+(defn- fake-hikari [url user closed?]
+  (proxy [HikariDataSource] []
+    (getJdbcUrl [] url)
+    (getUsername [] user)
+    (close [] (reset! closed? true))))
+
+(deftest test-add-connection-pool-does-not-leak
+  (testing "re-registering the same database reuses the pool instead of stacking a new one"
+    ;; The regression this guards: the id is derived from the pool's own
+    ;; host:port, so this always lands on the same key. A bare
+    ;; `swap! pools assoc` overwrote the entry and left the previous
+    ;; HikariDataSource open and unreferenced -- and since the pool config
+    ;; sets minimumIdle 1, each orphan held a real Postgres connection for
+    ;; the life of the process.
+    (let [first-closed? (atom false)
+          second-closed? (atom false)
+          url "jdbc:postgresql://leak-test:5432/app"]
+      (try
+        (with-redefs [connections/create-pool (fn [_] (fake-hikari url "app_user" first-closed?))]
+          (is (= "leak-test:5432" (connections/add-connection-pool {:host "leak-test"}))))
+        (with-redefs [connections/create-pool (fn [_] (fake-hikari url "app_user" second-closed?))]
+          (is (= "leak-test:5432" (connections/add-connection-pool {:host "leak-test"}))))
+
+        (is (not @first-closed?) "the pool still in the registry must stay open")
+        (is @second-closed? "the redundant second pool must be closed, not leaked")
+        (is (= 1 (count (filter #(= "leak-test:5432" %) (keys @connections/pools)))))
+        (finally
+          (swap! connections/pools dissoc "leak-test:5432")))))
+
+  (testing "a different database on the same host:port is rejected, leaving the existing pool untouched"
+    ;; A connection id is only host:port, so two different databases on one
+    ;; server collide on the same key and could never coexist here. The old
+    ;; code silently overwrote the entry, which pointed an existing
+    ;; connection id at a different database -- a correctness hazard on top
+    ;; of the leak. Closing the displaced pool instead would abort queries
+    ;; still running against a database the user may still be using, so this
+    ;; refuses rather than disturbing anything already registered.
+    (let [old-closed? (atom false)
+          new-closed? (atom false)]
+      (try
+        (with-redefs [connections/create-pool
+                      (fn [_] (fake-hikari "jdbc:postgresql://swap-test:5432/one" "u1" old-closed?))]
+          (connections/add-connection-pool {:host "swap-test"}))
+        (with-redefs [connections/create-pool
+                      (fn [_] (fake-hikari "jdbc:postgresql://swap-test:5432/two" "u1" new-closed?))]
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"already in use"
+                                (connections/add-connection-pool {:host "swap-test"}))))
+
+        (is (not @old-closed?) "the registered pool must not be closed out from under in-flight queries")
+        (is @new-closed? "the rejected pool must be closed, not leaked")
+        (is (= "jdbc:postgresql://swap-test:5432/one"
+               (.getJdbcUrl (@connections/pools "swap-test:5432")))
+            "the original registration must still be the one in the map")
+        (finally
+          (swap! connections/pools dissoc "swap-test:5432")))))
+
+  (testing "a different user on the same database is rejected too"
+    (let [old-closed? (atom false)
+          new-closed? (atom false)
+          url "jdbc:postgresql://user-test:5432/app"]
+      (try
+        (with-redefs [connections/create-pool (fn [_] (fake-hikari url "reader" old-closed?))]
+          (connections/add-connection-pool {:host "user-test"}))
+        (with-redefs [connections/create-pool (fn [_] (fake-hikari url "writer" new-closed?))]
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"already in use"
+                                (connections/add-connection-pool {:host "user-test"}))))
+
+        (is (not @old-closed?) "credentials differing must not silently take over the existing pool")
+        (is @new-closed? "the rejected pool must be closed, not leaked")
+        (finally
+          (swap! connections/pools dissoc "user-test:5432"))))))


### PR DESCRIPTION
Two independent bugs, both found while diagnosing a beamlynx-desktop session where every query hung while the server looked perfectly healthy.

**Per-query logging could deadlock the whole server.** The server printed the full SQL of every query it ran, to standard output. If whatever launched it was not reading that stream, the buffer filled and every print blocked permanently — taking the entire database layer with it. A thread dump showed 17 threads parked in a write inside `run-query`. Meanwhile `/api/v1/build` kept answering in 2ms, because it reads an in-memory index and never prints, so the server looked fine while no query ever completed.

Per-query logging is now off unless `PINE_LOG_QUERIES=1` is set. That also stops query text, including literal values, going to a stream nobody asked to receive it on. Startup messages are unchanged — there are few of them and they only appear when a connection is indexed.

**Registering an already-registered connection leaked a database connection every time.** A connection id is derived from its own host and port, so re-registering the same database always landed on the same key — and the pool it displaced was never closed. The pool config keeps one connection open at all times, so every orphan held a real database connection for the life of the process. 32 had accumulated in a single desktop session, against a default server limit of 100.

Registering the same database as the same user now reuses the existing pool.

**Behaviour change worth reviewing:** anything else landing on an id that is already taken is now rejected with an explanatory error, rather than silently taking the id over.

Rejecting rather than replacing is deliberate. Closing the displaced pool would fix the leak too, but it would abort queries still running on it — and since an id is only host and port, that pool could belong to a *different* database being actively queried. This takes nothing away: two databases on one server share an id and could never both be registered anyway. The old behaviour pointed an existing id at the new database, so queries a caller believed were running against the first quietly ran against the second. The error names the id and says to disconnect it first.

Consumers are unaffected in the normal case — beamlynx-ui re-registers the same database as the same user, which is the reuse path.