### PR TITLE
Release 0.41.0: data-driven access policy for restricted evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file. This change
 log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [0.41.0] - 2026-08-31
 ### Added
 - `/api/v1/build` and `/api/v1/eval` accept an optional `access-policy` rule array. Any column no rule allows comes back as `xxxxx` in the generated SQL instead of its real value; `.*` expansion is checked column-by-column. Rule types: `column-type` (allow-listed Postgres types), `foreign-key` (relation source columns), `column-name` (suffix match, e.g. `_id`). No policy given -- no change in behavior.
 - `information_schema`/`pg_catalog` are always exempt -- they're schema metadata, not application data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. This change
 log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Added
+- `/api/v1/build` and `/api/v1/eval` accept an optional `access-policy` rule array. Any column no rule allows comes back as `xxxxx` in the generated SQL instead of its real value; `.*` expansion is checked column-by-column. Rule types: `column-type` (allow-listed Postgres types), `foreign-key` (relation source columns), `column-name` (suffix match, e.g. `_id`). No policy given -- no change in behavior.
+- `information_schema`/`pg_catalog` are always exempt -- they're schema metadata, not application data.
 
 ## [0.40.0] - 2026-08-26
 ### Fixed

--- a/playground.docker-compose.yml
+++ b/playground.docker-compose.yml
@@ -18,7 +18,7 @@ services:
       retries: 10
 
   pine:
-    image: ahmadnazir/pine:0.40.0
+    image: ahmadnazir/pine:0.41.0
     container_name: pine_server
     depends_on:
       sample-db-ecommerce:

--- a/src/pine/access_policy.clj
+++ b/src/pine/access_policy.clj
@@ -1,0 +1,181 @@
+(ns pine.access-policy
+  "Per-connection, data-driven access policy for restricted evaluation.
+
+  A policy is a vector of rule maps, each carrying a :type discriminant
+  (a string, since rules travel as JSON over HTTP -- see api.clj's
+  :access-policy param). When a request's :access-policy is non-empty,
+  every SELECT column is checked against it: a column is shown as-is if
+  it's the structural auto-id column, or any rule matches; otherwise it's
+  rendered as a fixed literal directly in the generated SQL, so the real
+  value never leaves the database.
+
+  This module carries zero policy *content* of its own -- no hardcoded
+  allow-list, no notion of MCP. It only knows how to evaluate whatever
+  rules a caller supplies. Deciding what a connection's rules default to,
+  and letting an owner relax them, is entirely the caller's job (today:
+  beamlynx-desktop's credential-store.ts)."
+  (:require
+   [clojure.string :as s]
+   [pine.data-types :as dt]))
+
+(def redacted-value "xxxxx")
+(def redacted-sql-literal (str "'" redacted-value "'"))
+
+(defn sanitize-rules
+  "Coerce a raw, untrusted :access-policy value (parsed straight from an
+  HTTP JSON body) into a vector of well-shaped rule maps, dropping anything
+  that isn't a map with a string :type instead of erroring the request over
+  a malformed rule. Not a security boundary -- the caller who sends this
+  param could just as easily send an empty one to turn the policy off
+  outright, so there's nothing to defend against here beyond keeping a bad
+  request from crashing eval/build."
+  [raw]
+  (if (sequential? raw)
+    (filterv #(and (map? %) (string? (:type %))) raw)
+    []))
+
+(defn- column-db-type
+  "Resolve the real Postgres type for a SELECT column descriptor, using its
+  own already-resolved :source (set by ast/select.clj/ast/group.clj) when
+  present, falling back to the table alias's own entry in state's :aliases.
+  Returns nil when it can't be resolved at all (a computed/aggregate
+  expression with no real :column, or a table pine has no schema info for)."
+  [{:keys [references aliases]} alias column source]
+  (when-not (s/blank? column)
+    (when-let [table-info (or source (get aliases alias))]
+      (dt/get-column-type references alias column table-info))))
+
+(defn- column-table-info
+  "The {:table :schema} a SELECT column descriptor's own real table -- same
+  :source/:aliases fallback column-db-type uses, but returning the table
+  itself rather than looking up one column's type on it."
+  [{:keys [aliases]} alias source]
+  (or source (get aliases alias)))
+
+(def ^:private catalog-schemas
+  "Postgres's own schema-introspection views, not application data. The MCP
+  tool surface (beamlynx-desktop's find_tables/complete_query, and their own
+  descriptions) explicitly directs an agent to query information_schema.*
+  directly for schema discovery -- redacting it would silently defeat that
+  and return `xxxxx` for real table/column names, which are not sensitive
+  values in the first place. Exempt structurally, the same as an auto-id
+  column, not via a configurable rule: there's no legitimate policy under
+  which catalog metadata should be masked."
+  #{"information_schema" "pg_catalog"})
+
+(defn- catalog-column?
+  [state alias source]
+  (let [{:keys [schema]} (column-table-info state alias source)]
+    (contains? catalog-schemas schema)))
+
+(defn- foreign-key-source-column?
+  "Whether `column` is a source column of a detected foreign-key or
+  heuristic relation for `table` -- i.e. pine-lang's own join-relation
+  index (postgres.clj's index-foreign-keys/index-heuristic-relations,
+  both of which populate the same [:table T :refers-to ...] shape) already
+  treats it as identifier-shaped, real FK or naming-convention guess alike.
+  A lookup against index pine-lang builds anyway, not new indexing."
+  [references table column]
+  (boolean
+   (some (fn [[_target-table entry]] (contains? (:via entry) column))
+         (get-in references [:table table :refers-to]))))
+
+(defn- rule-matches?
+  "Whether one access-policy rule exempts this column from redaction.
+  Unrecognized :type values never match -- fail-closed, and forward-
+  compatible with a rule type a different pine-lang version doesn't know
+  about yet."
+  [state {:keys [column alias source]} rule]
+  (case (:type rule)
+    "column-type"
+    (contains? (set (:allow rule)) (column-db-type state alias column source))
+
+    "foreign-key"
+    (let [{:keys [table]} (column-table-info state alias source)]
+      (and table (not (s/blank? column))
+           (foreign-key-source-column? (:references state) table column)))
+
+    "column-name"
+    (and (:suffix rule) (not (s/blank? column)) (s/ends-with? column (:suffix rule)))
+
+    false))
+
+(defn sensitive-column?
+  "Whether a SELECT column descriptor should be redacted under `rules`.
+  Only meaningful when `rules` is non-empty -- callers gate on that
+  themselves (an empty/absent policy means no redaction at all, same as
+  before this module existed).
+
+  Auto-generated id columns and Postgres's own catalog views
+  (information_schema/pg_catalog -- see catalog-schemas) are always exempt.
+  Everything else is redacted unless some rule in `rules` matches --
+  including columns pine can't resolve a type or table for at all, such as
+  aggregates/computed expressions. Unknown defaults to protected, not
+  exposed: a raw aggregate like string_agg(email, ',') would otherwise be a
+  one-line bypass of the whole policy."
+  [state rules {:keys [alias source auto-id] :as col}]
+  (and (not auto-id)
+       (not (catalog-column? state alias source))
+       (not (some #(rule-matches? state col %) rules))))
+
+(defn- dedupe-by-column-name
+  "Keep only the first entry for each :column name, preserving order.
+  Needed because references' schema-less [:table table :columns] bucket
+  aggregates columns across every schema that has a same-named table (see
+  index-columns in postgres.clj) - an unqualified alias whose table name
+  happens to exist in more than one schema would otherwise expand into the
+  same column name twice."
+  [columns]
+  (->> columns
+       (reduce (fn [{:keys [seen out]} col]
+                 (if (contains? seen (:column col))
+                   {:seen seen :out out}
+                   {:seen (conj seen (:column col)) :out (conj out col)}))
+               {:seen #{} :out []})
+       :out))
+
+(defn- real-columns
+  "All real columns for a table alias, in schema order, from the
+  connection's indexed references."
+  [{:keys [references aliases]} alias]
+  (let [{:keys [table schema]} (get aliases alias)]
+    (dedupe-by-column-name
+     (if schema
+       (get-in references [:schema schema :table table :columns])
+       (get-in references [:table table :columns])))))
+
+(defn expand-star
+  "Explicit stand-in for `alias.*`, used only under the access policy: every
+  real column for the alias's table, in schema order, shaped like an
+  explicitly-selected column (ast/select.clj) so sensitive-column? and SQL
+  rendering treat it identically to one the user actually typed. A bare
+  `alias.*` is otherwise opaque to the per-column check redaction depends
+  on.
+
+  Returns nil when alias resolves to a variable/CTE rather than a real
+  table, so a bare `alias.*` is left as-is in that case: the CTE's own
+  inner query, built under the same policy, already redacted anything
+  sensitive at its source (see build-cte-body in eval.clj), so selecting
+  `.*` from it re-selects already-safe values - nothing left to redact a
+  second time, only real columns pine has no schema info for (a variable's
+  :columns) that this function has no way to enumerate."
+  [{:keys [aliases] :as state} current]
+  (let [{:keys [table schema] :as table-info} (get aliases current)]
+    (when (and table-info (not (:ast table-info)))
+      (mapv (fn [{:keys [column]}]
+              {:column column :alias current :source {:table table :schema schema}})
+            (real-columns state current)))))
+
+(defn expand-explicit-star
+  "`select: alias.*` (as opposed to the implicit current-table default
+  handled by expand-star) parses to a column descriptor with an empty
+  :column and :symbol \"*\" (see pine.parser's :star rule). It's just as
+  opaque to per-column redaction as the implicit form, so expand it the
+  same way. Returns a seq of one or more column descriptors: the expansion
+  when it succeeds, or the original descriptor unchanged (not real-column
+  data, so nothing to expand and nothing to redact by name) when it can't
+  be expanded - alias resolves to a variable/CTE rather than a real table."
+  [state {:keys [column symbol alias] :as col}]
+  (if (and (empty? column) (= symbol "*"))
+    (or (seq (expand-star state alias)) [col])
+    [col]))

--- a/src/pine/api.clj
+++ b/src/pine/api.clj
@@ -11,6 +11,7 @@
    [clojure.string :as str]
    [compojure.core :refer [defroutes DELETE GET POST]]
    [compojure.route :as route]
+   [pine.access-policy :as access-policy]
    [pine.ast.main :as ast]
    [pine.db.connections :as connections] ;; Encode arrays and json results in API responses
    [pine.db.main :as db]
@@ -41,10 +42,12 @@
   ([expression cursor connection-id]
    (generate-state expression cursor connection-id {}))
   ([expression cursor connection-id variables]
+   (generate-state expression cursor connection-id variables []))
+  ([expression cursor connection-id variables access-policy]
    (let [{:keys [result error]} (->> expression parser/parse)
          conn-id (or connection-id @db/connection-id)]
      (if result
-       {:result (ast/generate result conn-id expression cursor variables)}
+       {:result (ast/generate result conn-id expression cursor variables access-policy)}
        {:error-type "parse"
         :error error}))))
 
@@ -56,15 +59,17 @@
   point of assignment. An expression can assign multiple variables before its last op
   determines the final SQL. All assignments from one expression become available as
   CTE variables to the next."
-  [expressions connection-id]
-  (reduce (fn [{:keys [variables]} expression]
-            (let [{:keys [result error]} (generate-state expression nil connection-id variables)]
-              (if error
-                (reduced {:error error})
-                {:variables (merge variables (:pending-assignments result))
-                 :last-state result})))
-          {:variables {} :last-state nil}
-          expressions))
+  ([expressions connection-id]
+   (evaluate-expressions expressions connection-id []))
+  ([expressions connection-id access-policy]
+   (reduce (fn [{:keys [variables]} expression]
+             (let [{:keys [result error]} (generate-state expression nil connection-id variables access-policy)]
+               (if error
+                 (reduced {:error error})
+                 {:variables (merge variables (:pending-assignments result))
+                  :last-state result})))
+           {:variables {} :last-state nil}
+           expressions)))
 
 (defn- trim-pipes [s]
   (-> s
@@ -111,6 +116,8 @@
   ([expressions cursor]
    (api-build expressions cursor nil))
   ([expressions cursor connection-id]
+   (api-build expressions cursor connection-id []))
+  ([expressions cursor connection-id access-policy]
    (let [conn-id (or connection-id @db/connection-id)
          connection-name (connections/get-connection-name conn-id)]
      (try
@@ -121,16 +128,16 @@
              ;; empty :table op, which is what lets an empty input still show
              ;; table hints on Tab instead of "nothing found".
              last-expr     (or (last exprs) "")]
-         (let [{:keys [variables error]} (evaluate-expressions context-exprs conn-id)]
+         (let [{:keys [variables error]} (evaluate-expressions context-exprs conn-id access-policy)]
            (if error
              {:connection-id connection-name :error error}
-             (let [result                    (generate-state last-expr cursor conn-id variables)
+             (let [result                    (generate-state last-expr cursor conn-id variables access-policy)
                    {state :result build-error :error} result]
                (if build-error
                  {:connection-id connection-name :error build-error}
                  {:connection-id connection-name
                   :version version
-                  :query (-> last-expr trim-pipes (generate-state nil conn-id variables) :result eval/build-query eval/formatted-query)
+                  :query (-> last-expr trim-pipes (generate-state nil conn-id variables access-policy) :result eval/build-query eval/formatted-query)
                   :ast (prune-ast state)})))))
        (catch Exception e {:connection-id connection-name
                            :error (.getMessage e)})))))
@@ -157,6 +164,8 @@
   ([expressions]
    (api-eval expressions nil))
   ([expressions connection-id]
+   (api-eval expressions connection-id []))
+  ([expressions connection-id access-policy]
    (let [conn-id (or connection-id @db/connection-id)
          connection-name (connections/get-connection-name conn-id)]
      (try
@@ -166,10 +175,10 @@
              trimmed       (trim-pipes (or last-expr ""))]
          (if (str/blank? trimmed)
            {:connection-id connection-name}
-           (let [{:keys [variables error]} (evaluate-expressions context-exprs conn-id)]
+           (let [{:keys [variables error]} (evaluate-expressions context-exprs conn-id access-policy)]
              (if error
                {:connection-id connection-name :error error}
-               (let [{last-state :result build-error :error} (generate-state trimmed nil conn-id variables)]
+               (let [{last-state :result build-error :error} (generate-state trimmed nil conn-id variables access-policy)]
                  (if build-error
                    {:connection-id connection-name :error build-error}
                    (let [query (-> last-state eval/build-query eval/formatted-query)]
@@ -294,12 +303,14 @@
   ;; query building and evaluation
   (POST "/api/v1/build" {params :params}
     (let [{:keys [expressions expression cursor connection-id]} params
-          exprs (or expressions (when expression [expression]))]
-      (->> (api-build exprs cursor connection-id) response)))
+          exprs (or expressions (when expression [expression]))
+          rules (access-policy/sanitize-rules (:access-policy params))]
+      (->> (api-build exprs cursor connection-id rules) response)))
   (POST "/api/v1/eval" {params :params}
     (let [{:keys [expressions expression connection-id]} params
-          exprs (or expressions (when expression [expression]))]
-      (->> (api-eval exprs connection-id) response)))
+          exprs (or expressions (when expression [expression]))
+          rules (access-policy/sanitize-rules (:access-policy params))]
+      (->> (api-eval exprs connection-id rules) response)))
 
   ;; raw SQL execution
   (POST "/api/v1/sql" {params :params}

--- a/src/pine/ast/main.clj
+++ b/src/pine/ast/main.clj
@@ -36,6 +36,7 @@
             ;; - connection
             :connection-id nil
             :references {}
+            :access-policy []      ;; vector of rule maps (pine.access-policy); empty/absent = no redaction
             :variables {}               ;; {"varname" <nested-AST>}, populated from |= assignments in prior expressions
             :assign    nil              ;; variable name from the last |= op in this expression
             :pending-assignments {}     ;; {"varname" <state-snapshot>} accumulated by |= ops in this expression
@@ -119,15 +120,19 @@
   [variables]
   (count variables))
 
-(defn pre-handle [state connection-id ops-count expression cursor variables]
-  (-> state
-      (assoc :references (db/init-references connection-id))
-      (assoc :connection-id connection-id)
-      (assoc :pending-count ops-count)
-      (assoc :expression expression)
-      (assoc :cursor cursor)
-      (assoc :variables variables)
-      (assoc :auto-cte-count (next-auto-cte-count variables))))
+(defn pre-handle
+  ([state connection-id ops-count expression cursor variables]
+   (pre-handle state connection-id ops-count expression cursor variables []))
+  ([state connection-id ops-count expression cursor variables access-policy]
+   (-> state
+       (assoc :references (db/init-references connection-id))
+       (assoc :connection-id connection-id)
+       (assoc :pending-count ops-count)
+       (assoc :expression expression)
+       (assoc :cursor cursor)
+       (assoc :variables variables)
+       (assoc :access-policy (or access-policy []))
+       (assoc :auto-cte-count (next-auto-cte-count variables)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Checkpoint helpers
@@ -346,7 +351,13 @@
                                   (-> tables reverse rest reverse)
                                   tables)))
       add-prettify
-      (dissoc :references)))
+      ;; :references is normally internal-only scaffolding, dropped before the
+      ;; state is used further - but when :access-policy is non-empty, eval.clj
+      ;; needs it at SQL-render time to resolve each column's real DB type/table
+      ;; (see pine.access-policy). Nested variable/CTE snapshots (taken earlier,
+      ;; via assign/handle) already carry :references regardless, since this
+      ;; dissoc only ever runs once, on the final top-level state.
+      (#(if (seq (:access-policy %)) % (dissoc % :references)))))
 
 (defn generate
   ([parse-tree]
@@ -356,8 +367,10 @@
   ([parse-tree connection-id expression cursor]
    (generate parse-tree connection-id expression cursor {}))
   ([parse-tree connection-id expression cursor variables]
+   (generate parse-tree connection-id expression cursor variables []))
+  ([parse-tree connection-id expression cursor variables access-policy]
    (let [full-state (-> state
-                        (pre-handle connection-id (count parse-tree) expression cursor variables)
+                        (pre-handle connection-id (count parse-tree) expression cursor variables access-policy)
                         (handle-ops parse-tree))
          truncated-state (when (and cursor expression)
                            (generate-truncated-state expression cursor connection-id variables))]

--- a/src/pine/db/postgres.clj
+++ b/src/pine/db/postgres.clj
@@ -81,17 +81,26 @@ WHERE con.contype = 'f'
   is_nullable,
   column_default
 FROM information_schema.columns
-WHERE table_schema NOT IN ('pg_catalog', 'information_schema')"]
+WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
+ORDER BY table_schema, table_name, ordinal_position"]
     (with-open [conn (.getConnection pool)]
       (rest (jdbc/query {:connection conn} sql opts)))))
 
-(defn- index-columns [acc columns]
+(defn- index-columns
+  "Index columns per schema+table and per bare table name. :columns is kept
+  in the order given (ordinal position, per get-columns' ORDER BY) - the
+  access policy's `.*` expansion relies on this to lay out redacted columns
+  in the same order Postgres would give a real `SELECT *`. Plain `conj`
+  here would prepend (the accumulator starts from nil, and `(conj nil x)`
+  builds a list, not a vector), silently reversing that order - `(fnil conj
+  [])` seeds a vector instead, so conj appends."
+  [acc columns]
   (reduce (fn [acc [schema table col _pos type _len nullable default]]
             (let [col {:column col :type type :nullable nullable :default default}]
               (-> acc
-                  (update-in [:schema schema :table table :columns] conj col)
+                  (update-in [:schema schema :table table :columns] (fnil conj []) col)
                   (update-in [:schema schema :table table :column-set] (fnil conj #{}) col)
-                  (update-in [:table table :columns] conj col)
+                  (update-in [:table table :columns] (fnil conj []) col)
                   (update-in [:table table :column-set] (fnil conj #{}) col))))
           acc
           columns))

--- a/src/pine/eval.clj
+++ b/src/pine/eval.clj
@@ -1,6 +1,7 @@
 (ns pine.eval
   (:require
    [clojure.string :as s]
+   [pine.access-policy :as access-policy]
    [pine.db.main :as db]))
 
 (defn q
@@ -42,22 +43,46 @@
                                joins)]
       (s/join " " join-statements))))
 
-(defn- build-columns-clause [{:keys [operation columns current]}]
+(defn- build-columns-clause [{:keys [operation columns current] :as state}]
   (let [type (-> operation :type)
+        rules (:access-policy state)
+        restricted? (seq rules)
+        ;; An explicit `select: alias.*` is just as opaque to per-column
+        ;; redaction as the implicit current-table `.*` handled below -
+        ;; expand it first so the rest of this function only ever sees real
+        ;; columns (or, for a variable/CTE alias, is left untouched).
+        ;; vec, not mapcat's lazy seq: the later `(into columns expanded)`
+        ;; below relies on conj appending (vector semantics) - conj on a
+        ;; plain seq prepends instead, which would silently put every
+        ;; expanded/auto-id column in reverse order.
+        columns (if restricted?
+                  (vec (mapcat #(access-policy/expand-explicit-star state %) columns))
+                  columns)
         ;; Separate auto-ID columns from user-selected columns
         {auto-id-columns true user-columns nil} (group-by #(:auto-id %) columns)
         ;; Check if any non-auto-ID columns are selected for the current table
         current-table-has-columns? (some #(= (:alias %) current) user-columns)
+        star-eligible? (not (contains? #{:select :delete-action :group} type))
+        ;; Under the access policy, a bare `current.*` is opaque to the
+        ;; per-column check redaction depends on - expand it into an
+        ;; explicit column list (pine.access-policy/expand-star) so each one
+        ;; can be checked and redacted individually. Policy off: unchanged.
+        expanded (when (and restricted? star-eligible? (not current-table-has-columns?))
+                   (access-policy/expand-star state current))
+        columns (if (seq expanded) (into columns expanded) columns)
+        current-table-has-columns? (or current-table-has-columns? (seq expanded))
         select-all (cond
-                     (contains? #{:select :delete-action :group} type) ""
+                     (not star-eligible?) ""
                      current-table-has-columns? ""  ; Don't add .* if current table has explicit columns
                      :else (str (if (seq columns) ", " "") (q current) ".*"))]
     (str
      "SELECT "
      (s/join
       ", "
-      (map (fn [{:keys [column alias column-alias symbol auto-id col-fn]}]
-             (let [c (cond
+      (map (fn [{:keys [column alias column-alias symbol auto-id col-fn] :as col}]
+             (let [redact? (and restricted? (access-policy/sensitive-column? state rules col))
+                   c (cond
+                       redact? access-policy/redacted-sql-literal
                        ;; Auto-ID columns should render as unquoted id
                        auto-id (str (q alias) ".id")
                        ;; Column function (currently date functions)
@@ -65,8 +90,12 @@
                        ;; Symbol-based columns (like aggregates)
                        (empty? column) (if alias (str (q alias) "." symbol) symbol)
                        ;; Regular columns
-                       :else (q alias column))]
-               (if column-alias (str c " AS " (q column-alias)) c))) columns))
+                       :else (q alias column))
+                   ;; A redacted literal loses Postgres' automatic naming of a
+                   ;; bare column reference, so name it explicitly whenever no
+                   ;; explicit column-alias was already going to do that job.
+                   out-alias (or column-alias (when redact? (if (empty? column) symbol column)))]
+               (if out-alias (str c " AS " (q out-alias)) c))) columns))
      select-all
      " FROM")))
 
@@ -201,10 +230,14 @@
                           :columns non-aggregate-cols
                           :operation {:type :group})
         ;; Build SELECT clause using the same logic as regular queries, but add aliases to all columns
+        rules (:access-policy state)
+        restricted? (seq rules)
         select-parts (s/join
                       ", "
-                      (map (fn [{:keys [column alias column-alias symbol auto-id col-fn]}]
-                             (let [c (cond
+                      (map (fn [{:keys [column alias column-alias symbol auto-id col-fn] :as col}]
+                             (let [redact? (and restricted? (access-policy/sensitive-column? state rules col))
+                                   c (cond
+                                       redact? access-policy/redacted-sql-literal
                                        ;; Auto-ID columns should render as unquoted id
                                        auto-id (str (q alias) ".id")
                                        ;; Column function (currently date functions)

--- a/src/pine/version.clj
+++ b/src/pine/version.clj
@@ -1,3 +1,3 @@
 (ns pine.version)
 
-(def version "0.40.0")
+(def version "0.41.0")

--- a/test/pine/eval_test.clj
+++ b/test/pine/eval_test.clj
@@ -7,26 +7,30 @@
 
 (defn- generate
   "Helper function to generate the sql"
-  [expression]
-  (-> expression
-      parser/parse
-      :result
-      (ast/generate :test)
-      eval/build-query))
+  ([expression]
+   (generate expression []))
+  ([expression access-policy]
+   (-> expression
+       parser/parse
+       :result
+       (ast/generate :test nil nil {} access-policy)
+       eval/build-query)))
 
 (defn- generate-expressions
   "Evaluate a list of pine expressions sequentially, threading variables.
   Returns the SQL of the last expression."
-  [expressions]
-  (let [{:keys [last-state]}
-        (reduce (fn [{:keys [variables]} expr]
-                  (let [{:keys [result]} (parser/parse expr)
-                        state (ast/generate result :test nil nil variables)]
-                    {:variables (merge variables (:pending-assignments state))
-                     :last-state state}))
-                {:variables {} :last-state nil}
-                expressions)]
-    (eval/build-query last-state)))
+  ([expressions]
+   (generate-expressions expressions []))
+  ([expressions access-policy]
+   (let [{:keys [last-state]}
+         (reduce (fn [{:keys [variables]} expr]
+                   (let [{:keys [result]} (parser/parse expr)
+                         state (ast/generate result :test nil nil variables access-policy)]
+                     {:variables (merge variables (:pending-assignments state))
+                      :last-state state}))
+                 {:variables {} :last-state nil}
+                 expressions)]
+     (eval/build-query last-state))))
 
 (deftest test-build-query
 
@@ -742,3 +746,78 @@
       ;; Each one's own checkpoint must still carry the right GROUP BY body.
       (is (clojure.string/includes? query (str "\"" x-name "\" AS ( SELECT \"c\".\"id\", COUNT(1) AS \"count\"")))
       (is (clojure.string/includes? query (str "\"" y-name "\" AS ( SELECT \"c\".\"id\", COUNT(1) AS \"count\""))))))
+
+(def ^:private column-type-rule
+  ;; Mirrors the values beamlynx-desktop seeds a new connection's default
+  ;; policy with (DEFAULT_ACCESS_POLICY_RULES, credential-store.ts) -- this
+  ;; module itself carries no default of its own, so tests construct their
+  ;; own rule vectors explicitly rather than reaching for a shared default.
+  {:type "column-type"
+   :allow ["uuid" "boolean" "bool"
+           "smallint" "integer" "bigint" "int2" "int4" "int8"
+           "numeric" "decimal" "real" "double precision" "float4" "float8" "money"
+           "date" "time" "time without time zone" "time with time zone"
+           "timestamp" "timestamp without time zone" "timestamp with time zone" "timestamptz"
+           "USER-DEFINED"]})
+
+(deftest test-access-policy
+  ;; `report` (fixtures.clj) has a "character varying" column (title) alongside
+  ;; an "integer" id - a real non-allow-listed type next to an allowed one.
+  ;; `order` has a "character varying" customer_id that's a heuristic (not a
+  ;; real FK) join source - fixtures.clj deliberately types it that way to
+  ;; test the same cross-family-type join casting elsewhere in this file.
+
+  (testing "Policy off (default, empty/absent rules): unaffected, even for a table with a text column"
+    (is (= "SELECT \"r_0\".id AS \"__r_0__id\", \"r_0\".* FROM \"report\" AS \"r_0\" LIMIT 1"
+           (:query (generate "report | limit: 1")))))
+
+  (testing "column-type rule: implicit `.*` is expanded and the text column is redacted"
+    (is (= "SELECT \"r_0\".id AS \"__r_0__id\", \"r_0\".\"id\", 'xxxxx' AS \"title\" FROM \"report\" AS \"r_0\" LIMIT 1"
+           (:query (generate "report | limit: 1" [column-type-rule])))))
+
+  (testing "column-type rule: an explicitly selected text column is redacted, its name preserved"
+    (is (= "SELECT 'xxxxx' AS \"title\", \"r_0\".\"id\", \"r_0\".id AS \"__r_0__id\" FROM \"report\" AS \"r_0\" LIMIT 250"
+           (:query (generate "report | select: title, id" [column-type-rule])))))
+
+  (testing "column-type rule: allowed types (uuid, integer) pass through untouched; jsonb does not"
+    (is (= "SELECT \"c_0\".id AS \"__c_0__id\", \"c_0\".\"id\", 'xxxxx' AS \"data\", \"c_0\".\"uuid_col\" FROM \"customer\" AS \"c_0\" LIMIT 1"
+           (:query (generate "customer | limit: 1" [column-type-rule])))))
+
+  (testing "column-type rule: a table with no sensitive columns renders exactly as it would unrestricted, apart from being expanded"
+    (is (= "SELECT \"c_0\".id AS \"__c_0__id\", \"c_0\".\"id\", \"c_0\".\"created_at\" FROM \"company\" AS \"c_0\" LIMIT 1"
+           (:query (generate "company | limit: 1" [column-type-rule])))))
+
+  (testing "column-type rule: a varchar-typed FK-shaped column stays redacted -- type is the only signal this rule has"
+    (is (= "SELECT \"o_0\".id AS \"__o_0__id\", \"o_0\".\"id\", 'xxxxx' AS \"customer_id\", \"o_0\".\"user_id\" FROM \"order\" AS \"o_0\" LIMIT 1"
+           (:query (generate "order | limit: 1" [column-type-rule])))))
+
+  (testing "foreign-key rule: unmasks that same column once added, real FK or heuristic relation alike"
+    (is (= "SELECT \"o_0\".id AS \"__o_0__id\", \"o_0\".\"id\", \"o_0\".\"customer_id\", \"o_0\".\"user_id\" FROM \"order\" AS \"o_0\" LIMIT 1"
+           (:query (generate "order | limit: 1" [column-type-rule {:type "foreign-key"}])))))
+
+  (testing "column-name rule: unmasks the same column by suffix alone, with no foreign-key rule present -- the weaker, opt-in signal"
+    (is (= "SELECT \"o_0\".id AS \"__o_0__id\", \"o_0\".\"id\", \"o_0\".\"customer_id\", \"o_0\".\"user_id\" FROM \"order\" AS \"o_0\" LIMIT 1"
+           (:query (generate "order | limit: 1" [column-type-rule {:type "column-name" :suffix "_id"}])))))
+
+  (testing "An unrecognized rule type matches nothing -- fail-closed and forward-compatible, not an error"
+    (is (= "SELECT \"r_0\".id AS \"__r_0__id\", 'xxxxx' AS \"id\", 'xxxxx' AS \"title\" FROM \"report\" AS \"r_0\" LIMIT 1"
+           (:query (generate "report | limit: 1" [{:type "some-future-rule-type" :whatever "x"}])))))
+
+  (testing "information_schema/pg_catalog are structurally exempt, regardless of rules -- catalog metadata, not application data. The MCP tool surface's own docs tell an agent to query information_schema.* directly for schema discovery; redacting it would silently defeat that."
+    (is (= "SELECT \"c_0\".\"table_name\", \"c_0\".\"column_name\" FROM \"information_schema\".\"columns\" AS \"c_0\" LIMIT 250"
+           (:query (generate "information_schema.columns | select: table_name, column_name" [{:type "column-name" :suffix "-never-matches"}]))))
+    (is (= "SELECT \"pt_0\".\"typname\" FROM \"pg_catalog\".\"pg_type\" AS \"pt_0\" LIMIT 250"
+           (:query (generate "pg_catalog.pg_type | select: typname" [{:type "column-name" :suffix "-never-matches"}])))))
+
+  (testing "column-type rule: an explicit per-alias star (`select: alias.*`, distinct from the implicit current-table default) is expanded and redacted too"
+    (is (= "SELECT \"r\".\"id\", 'xxxxx' AS \"title\", \"r\".id AS \"__r__id\" FROM \"report\" AS \"r\" LIMIT 250"
+           (:query (generate "report as r | s: r.*" [column-type-rule])))))
+
+  (testing "column-type rule: a variable's own CTE body redacts at its source; the outer `.*` re-selects the already-safe result"
+    (let [query (:query (generate-expressions ["report |= r" "r | limit: 1"] [column-type-rule]))]
+      (is (clojure.string/includes? query "\"r\" AS ( SELECT \"r_0\".\"id\", 'xxxxx' AS \"title\" FROM \"report\" AS \"r_0\" )"))
+      (is (clojure.string/includes? query "SELECT \"r\".* FROM \"r\" AS \"r\""))))
+
+  (testing "column-type rule: GROUP BY a redacted column still runs, but every group collapses to the placeholder - a known tradeoff, not a leak"
+    (is (= "WITH \"x_1\" AS ( SELECT 'xxxxx' AS \"title\" FROM \"report\" AS \"r_0\" ) SELECT \"x_1\".\"title\", COUNT(1) AS \"count\" FROM \"x_1\" GROUP BY \"x_1\".\"title\""
+           (:query (generate "report | group: title => count" [column-type-rule]))))))


### PR DESCRIPTION
## Summary
- New `access-policy` rule array accepted by `/api/v1/build`/`/api/v1/eval`: any column no rule allows comes back as `xxxxx` directly in the generated SQL, so the real value never leaves the database. Three rule types: `column-type`, `foreign-key`, `column-name` (suffix match).
- `information_schema`/`pg_catalog` are always exempt as schema metadata.
- Also fixes a column-ordering bug and a duplicate-columns bug in `.*` expansion, both found while building this.

## Test plan
- [x] `clj -M:test` -- 535 assertions, 0 failures
- [x] `./scripts/check-version-sync.sh` -- passes at 0.41.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)