### PR TITLE
Release 0.42.0: /api/v1/eval now returns prettified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file. This change
 log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [0.42.0] - 2026-09-02
 ### Added
 - `/api/v1/eval` now also returns `prettified` (a nicely formatted rendering of the expression that ran), the same value `/api/v1/build` already returned. It was already computed internally on every request; callers that want to show an evaluated expression cleanly no longer need a second `/api/v1/build` round trip to get it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file. This change
 log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Added
+- `/api/v1/eval` now also returns `prettified` (a nicely formatted rendering of the expression that ran), the same value `/api/v1/build` already returned. It was already computed internally on every request; callers that want to show an evaluated expression cleanly no longer need a second `/api/v1/build` round trip to get it.
 
 ## [0.41.0] - 2026-08-31
 ### Added

--- a/playground.docker-compose.yml
+++ b/playground.docker-compose.yml
@@ -18,7 +18,7 @@ services:
       retries: 10
 
   pine:
-    image: ahmadnazir/pine:0.41.0
+    image: ahmadnazir/pine:0.42.0
     container_name: pine_server
     depends_on:
       sample-db-ecommerce:

--- a/src/pine/api.clj
+++ b/src/pine/api.clj
@@ -191,10 +191,17 @@
                          {:connection-id connection-name
                           :version version
                           :result rows
-                          :columns columns})
+                          :columns columns
+                          ;; Already computed as part of generate-state's shared
+                          ;; post-handle pipeline (ast/main.clj's add-prettify runs
+                          ;; on every build or eval alike) - free to expose here
+                          ;; without a second /api/v1/build round trip, unlike
+                          ;; client.ts's prettify() which pays for one on purpose.
+                          :prettified (:prettified last-state)})
                        (catch Exception e {:connection-id connection-name
                                            :error (.getMessage e)
-                                           :query query})))))))))
+                                           :query query
+                                           :prettified (:prettified last-state)})))))))))
        (catch Exception e {:connection-id connection-name
                            :error (.getMessage e)})))))
 

--- a/src/pine/version.clj
+++ b/src/pine/version.clj
@@ -1,3 +1,3 @@
 (ns pine.version)
 
-(def version "0.41.0")
+(def version "0.42.0")


### PR DESCRIPTION
## Summary
`/api/v1/build` has always returned `ast.prettified`, a nicely formatted rendering of the expression. It turns out pine-lang already computes this value on every request -- build or eval -- as part of the shared generate-state pipeline; `/api/v1/eval` just never included it in its response.

This exposes it there too, at no extra cost. Callers that want to show an evaluated expression cleanly (e.g. beamlynx-ui's MCP-run queries) no longer need a second `/api/v1/build` round trip just to get it.

## Test plan
- [x] Full test suite passes (`clj -M:test`)
- [x] `./scripts/check-version-sync.sh` passes
- [x] Formatter run (`clj -M:fmt fix`)